### PR TITLE
downtime remove: fix objecttype column name

### DIFF
--- a/application/controllers/DowntimeController.php
+++ b/application/controllers/DowntimeController.php
@@ -26,7 +26,7 @@ class Deployment_DowntimeController extends ApiController
         $columns = array(
             'host'        => 'host_name',
             'service'     => 'service_description',
-            'objecttype'  => 'downtime_objecttype',
+            'objecttype'  => 'object_type',
             'internal_id' => 'downtime_internal_id'
         );
 


### PR DESCRIPTION
Before this fix, this fails with:

```
#0 /usr/share/icingaweb2/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php(750): Icinga\Module\Monitoring\Backend\Ido\Query\IdoQuery-&gt;requireColumn('downtime_object...')
#1 /usr/share/icingaweb2/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php(1057): Icinga\Module\Monitoring\Backend\Ido\Query\IdoQuery-&gt;resolveColumns(Array)
#2 /usr/share/php/Icinga/Data/SimpleQuery.php(124): Icinga\Module\Monitoring\Backend\Ido\Query\IdoQuery-&gt;columns(Array)
#3 /usr/share/icingaweb2/modules/monitoring/library/Monitoring/Backend/MonitoringBackend.php(305): Icinga\Data\SimpleQuery-&gt;__construct(Object(Icinga\Data\Db\DbConnection), Array)
#4 /usr/share/icingaweb2/modules/monitoring/library/Monitoring/DataView/DataView.php(53): Icinga\Module\Monitoring\Backend\MonitoringBackend-&gt;query('Downtime', Array)
#5 /usr/share/icingaweb2/modules/monitoring/library/Monitoring/Backend/MonitoringBackend.php(260): Icinga\Module\Monitoring\DataView\DataView-&gt;__construct(Object(Icinga\Module\Monitoring\Backend\Ido\IdoBackend), Array)
#6 /usr/share/icingaweb2/modules/deployment/application/controllers/DowntimeController.php(35): Icinga\Module\Monitoring\Backend\MonitoringBackend-&gt;from('downtime', Array)
#7 /usr/share/php/Zend/Controller/Action.php(516): Deployment_DowntimeController-&gt;removeAction()
#8 /usr/share/php/Zend/Controller/Dispatcher/Standard.php(308): Zend_Controller_Action-&gt;dispatch('removeAction')
#9 /usr/share/php/Icinga/Web/Controller/Dispatcher.php(56): Zend_Controller_Dispatcher_Standard-&gt;dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
#10 /usr/share/php/Zend/Controller/Front.php(954): Icinga\Web\Controller\Dispatcher-&gt;dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
#11 /usr/share/php/Icinga/Application/Web.php(390): Zend_Controller_Front-&gt;dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
#12 /usr/share/php/Icinga/Application/webrouter.php(109): Icinga\Application\Web-&gt;dispatch()
#13 /usr/share/icingaweb2/public/index.php(4): require_once('/usr/share/php/...')
#14 {main}
```

@Thomas-Gelf : Mind to take a look? I am unsure if `if ($downtime->objecttype === 'service')` still works correctly. Can you confirm?
