### PR TITLE
downtimes: fix remove

### DIFF
--- a/application/controllers/DowntimeController.php
+++ b/application/controllers/DowntimeController.php
@@ -45,8 +45,7 @@ class Deployment_DowntimeController extends ApiController
                 $object = $this->getHostObject($downtime->host);
             }
             $cmd = new DeleteDowntimeCommand();
-            $cmd->setObject($object)
-                ->setDowntimeId($downtime->internal_id);
+            $cmd->setDowntimeId($downtime->internal_id);
             $this->getTransport()->send($cmd);
         }
 


### PR DESCRIPTION
This fixes:

```
<b>Fatal error</b>:  Call to undefined method Icinga\Module\Monitoring\Command\Object\DeleteDowntimeCommand::setObject() in <b>/usr/share/icingaweb2/modules/deployment/application/controllers/DowntimeController.php</b> on line <b>48</b><br />
```
